### PR TITLE
Pipeline fix 2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 1.2.3 / 2022-06-10
+
+- Restored to .NET 6
+- Parameterized pipeline container demands
+
 ## 1.2.2 / 2022-06-09
 
 - Updated dependencies

--- a/OpenWeather/OpenWeather.csproj
+++ b/OpenWeather/OpenWeather.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/OpenWeatherTests/OpenWeatherTests.csproj
+++ b/OpenWeatherTests/OpenWeatherTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub. The samples also work on OSIsoft Cloud Services unless otherwise noted. |
 | -----------------------------------------------------------------------------------------------|  
 
-**Version:** 1.2.2
+**Version:** 1.2.3
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OMF/aveva.sample-omf-azure_functions-dotnet?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2632&branchName=main)
 
@@ -13,7 +13,7 @@ This sample uses Azure Functions and OSIsoft Message Format to send real time da
 
 The [.NET Core CLI](https://docs.microsoft.com/en-us/dotnet/core/tools/) is referenced in this sample, and should be installed to run the sample from the command line.
 
-This sample uses .NET 5.0
+This sample uses .NET 6.0
 
 In order to run this sample as an Azure Function App, a subscription to Microsoft Azure is required. Note that the published Azure Function App may add to Azure subscription costs, so it should be stopped or deleted after use.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,11 +33,15 @@ variables:
   - name: analysisProject
     value: AzureFunctions_DotNet
 
+parameters:
+  - name: containerDemands
+    default: Agent.OS -equals Windows_NT
+
 jobs:
   - job: Tests
     pool:
       name: 00-OSIManaged-Containers
-      demands: Agent.OS -equals Windows_NT
+      demands: ${{ parameters.containerDemands }}
     variables:
       - name: AdhTenantId
         value: $(TenantId)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,14 +51,19 @@ jobs:
         value: $(Resource)
     steps:
       - task: UseDotNet@2
-        displayName: 'Install dotnet 5'
+        displayName: 'Install dotnet 6'
         inputs:
           packageType: 'sdk'
-          version: '5.x'
+          version: '6.x'
 
       - template: '/miscellaneous/build_templates/appsettings.yml@templates'
         parameters:
           secrets: 'TenantId, NamespaceId, ClientId, ClientSecret, OpenWeatherKey, Resource'
+
+      - task: DotNetCoreCLI@2
+        displayName: 'Nuget restore'
+        inputs:
+          command: restore
 
       - task: DotNetCoreCLI@2
         displayName: 'Run tests'
@@ -71,10 +76,10 @@ jobs:
     parameters:
       buildSteps:
         - task: UseDotNet@2
-          displayName: 'Install dotnet 5'
+          displayName: 'Install dotnet 6'
           inputs:
             packageType: 'sdk'
-            version: '5.x'
+            version: '6.x'
 
         - task: DotNetCoreCLI@2
           displayName: 'Nuget restore'


### PR DESCRIPTION
figured out a better fix for the failing nuget restore commands, which started failing for .NET 5 as well once it was merged into main. If .NET 5 is also failing, there's no reason to roll back to it, and this fix of manually running the nuget restore task, rather than letting it be implicitly called as part of the dotnet build task, has been very robust up to this point.

Since this is in PR, added the parameterization of the container demands while we're at it. 